### PR TITLE
Replace mockito with a concrete implementation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 script:
   - sbt clean coverage test
 scala:
-  - 2.10.5
-  - 2.11.6
+  - 2.10.6
+  - 2.11.7
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 name := "play-mockws"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.10.5", "2.11.6")
+crossScalaVersions := Seq("2.10.6", "2.11.7")
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 organization := "de.leanovate.play-mockws"
 
-val playVersion = "2.3.7"
+val playVersion = "2.3.10"
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,13 +15,13 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % playVersion % "provided",
   "com.typesafe.play" %% "play-ws" % playVersion % "provided",
-  "com.typesafe.play" %% "play-test" % playVersion % "provided" excludeAll ExclusionRule(organization = "org.specs2"),
-  "org.mockito" % "mockito-core" % "1.10.19" % "provided"
+  "com.typesafe.play" %% "play-test" % playVersion % "provided" excludeAll ExclusionRule(organization = "org.specs2")
 )
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4",
-  "org.scalacheck" %% "scalacheck" % "1.12.2"
+  "org.scalacheck" %% "scalacheck" % "1.12.2",
+  "org.mockito" % "mockito-core" % "1.10.19"
 ) map (_ % "test")
 
 Release.settings

--- a/src/main/scala/mockws/FakeAhcResponse.scala
+++ b/src/main/scala/mockws/FakeAhcResponse.scala
@@ -1,0 +1,89 @@
+package mockws
+
+import java.io.{ByteArrayInputStream, InputStream}
+import java.net.URI
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.util
+import java.util.Collections
+
+import com.ning.http.client.cookie.{Cookie, CookieDecoder}
+import com.ning.http.client.{FluentCaseInsensitiveStringsMap, Response}
+import com.ning.http.util.AsyncHttpProviderUtils
+import org.jboss.netty.handler.codec.http.HttpResponseStatus
+import play.api.mvc.Result
+
+import scala.collection.JavaConversions._
+
+/**
+ * A simulated response from the async-http-client.
+ *
+ * The [[play.api.libs.ws.ning.NingWSResponse]] is intended to wrap this.
+ *
+ * Implementation is mostly based off of [[com.ning.http.client.providers.netty.NettyResponse]].
+ *
+ * We're faking at this level as opposed to the [[play.api.libs.ws.WSResponse]] level
+ * to preserve any behavior specific to the NingWSResponse which is likely to be used
+ * in the real (non-fake) WSClient.
+ */
+class FakeAhcResponse(result: Result, body: Array[Byte]) extends Response {
+
+  private val NettyDefaultCharset: Charset = Charset.forName("ISO-8859-1")
+
+  override def getResponseBodyAsByteBuffer: ByteBuffer = ByteBuffer.wrap(body)
+
+  override def getResponseBodyExcerpt(maxLength: Int, charset: String): String = getResponseBody(charset).take(maxLength)
+
+  override def getResponseBodyExcerpt(maxLength: Int): String = getResponseBodyExcerpt(maxLength, null)
+
+  override def getStatusCode: Int = result.header.status
+
+  override def getResponseBodyAsBytes: Array[Byte] = body
+
+  override def getResponseBodyAsStream: InputStream = new ByteArrayInputStream(body)
+
+  override def isRedirected: Boolean = Set(301, 302, 303, 307, 308).contains(getStatusCode)
+
+  override def getCookies: util.List[Cookie] = getHeaders("Set-Cookie").map(CookieDecoder.decode)
+
+  override def hasResponseBody: Boolean = body.nonEmpty
+
+  override def getStatusText: String = HttpResponseStatus.valueOf(getStatusCode).toString
+
+  override def getHeaders(name: String): util.List[String] = {
+    Option(getHeaders.get(name)).getOrElse(Collections.emptyList())
+  }
+
+  override def getHeaders: FluentCaseInsensitiveStringsMap = {
+    val scalaHeaders = FakeWSResponseHeaders.toMultiMap(result.header)
+    val javaHeaders = mapAsJavaMap(scalaHeaders.mapValues(v => asJavaCollection(v)))
+
+    new FluentCaseInsensitiveStringsMap(javaHeaders)
+  }
+
+  override def hasResponseHeaders: Boolean = true // really asking if the request has been completed.
+
+  override def getResponseBody(charset: String): String = new String(body, computeCharset(charset))
+
+  override def getResponseBody: String = getResponseBody(null)
+
+  override def getContentType: String = getHeader("Content-Type")
+
+  override def hasResponseStatus: Boolean = true // really asking if the request has been completed.
+
+  override def getUri: URI = throw new NotImplementedError("unavailable here and unused by NingWSResponse")
+
+  override def getHeader(name: String): String = getHeaders.getFirstValue(name)
+
+  private def computeCharset(charset: String): Charset = {
+    Option(charset)
+      .orElse(charsetFromContentType)
+      .map(Charset.forName)
+      .getOrElse(NettyDefaultCharset)
+  }
+
+  private def charsetFromContentType: Option[String] = {
+    Option(getContentType)
+      .flatMap(ct => Option(AsyncHttpProviderUtils.parseCharset(ct)))
+  }
+}

--- a/src/main/scala/mockws/FakeWSRequestHolder.scala
+++ b/src/main/scala/mockws/FakeWSRequestHolder.scala
@@ -1,0 +1,124 @@
+package mockws
+
+import java.net.URLEncoder
+
+import mockws.MockWS.Routes
+import org.slf4j.LoggerFactory
+import play.api.libs.iteratee.{Enumerator, Iteratee}
+import play.api.libs.ws._
+import play.api.libs.ws.ning.NingWSResponse
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+case class FakeWSRequestHolder(
+  routes: Routes,
+  url: String,
+  method: String = "GET",
+  body: WSBody = EmptyBody,
+  headers: Map[String, Seq[String]] = Map.empty,
+  queryString: Map[String, Seq[String]] = Map.empty,
+  requestTimeout: Option[Int] = None,
+  timeoutProvider: TimeoutProvider = SchedulerExecutorServiceTimeoutProvider
+  ) extends WSRequestHolder {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /* Not implemented. */
+  override val auth: Option[(String, String, WSAuthScheme)] = None
+  override val calc: Option[WSSignatureCalculator] = None
+  override val followRedirects: Option[Boolean] = None
+  override val proxyServer: Option[WSProxyServer] = None
+  override val virtualHost: Option[String] = None
+
+  def withAuth(username: String, password: String, scheme: WSAuthScheme) = this
+
+  def sign(calc: WSSignatureCalculator): WSRequestHolder = this
+
+  def withFollowRedirects(follow: Boolean) = this
+
+  def withProxyServer(proxyServer: WSProxyServer) = this
+
+  def withVirtualHost(vh: String) = this
+
+  def withBody(body: WSBody) = copy(body = body)
+
+  def withMethod(method: String) = copy(method = method)
+
+  def withHeaders(hdrs: (String, String)*) = {
+    val headers = hdrs.foldLeft(this.headers)(
+      (m, hdr) =>
+        if (m.contains(hdr._1)) m.updated(hdr._1, m(hdr._1) :+ hdr._2)
+        else m + (hdr._1 -> Seq(hdr._2))
+    )
+    copy(headers = headers)
+  }
+
+  def withQueryString(parameters: (String, String)*) = copy(
+    queryString = parameters.foldLeft(queryString) {
+      case (m, (k, v)) => m + (k -> (v +: m.getOrElse(k, Nil)))
+    }
+  )
+
+  def withRequestTimeout(timeout: Int) = copy(requestTimeout = Some(timeout))
+
+  def execute(): Future[WSResponse] = for {
+    result <- executeResult()
+    responseBodyBytes <- result.body |>>> Iteratee.consume[Array[Byte]]()
+  } yield new NingWSResponse(new FakeAhcResponse(result, responseBodyBytes))
+
+  def stream(): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = {
+    executeResult().map(result => (new FakeWSResponseHeaders(result), result.body))
+  }
+
+  private def executeResult(): Future[Result] = {
+    logger.debug(s"calling $method $url")
+
+    val action = routes.lift((method, url)).getOrElse(throw new Exception(s"no route defined for $method $url"))
+    def fakeRequest = FakeRequest(method, urlWithQueryParams()).withHeaders(headersSeq(): _*)
+
+    // Real WSClients will actually interrupt the response Enumerator while it's streaming.
+    // I don't want to go down that rabbit hole. This is close enough for most cases.
+    applyRequestTimeout(fakeRequest) {
+      requestBodyEnumerator |>>> action(fakeRequest)
+    }
+  }
+
+  private def applyRequestTimeout[T](req: FakeRequest[_])(future: Future[T]) = requestTimeout match {
+    case Some(delay) => timeoutProvider.timeout(
+      future = future,
+      delay = delay.millis,
+      timeoutMsg = s"Request ${req.method} ${req.uri} timed out after $delay ms."
+    )
+    case None => future
+  }
+
+  private def requestBodyEnumerator: Enumerator[Array[Byte]] = body match {
+    case EmptyBody => Enumerator.eof
+    case FileBody(file) => Enumerator.fromFile(file)
+    case InMemoryBody(bytes) => Enumerator(bytes)
+    case StreamedBody(enumerator) => enumerator
+  }
+
+  private def headersSeq(): Seq[(String, String)] = for {
+    (key, values) <- headers.toSeq
+    value <- values
+  } yield key -> value
+
+  private def urlWithQueryParams() = if (queryString.isEmpty) {
+    url
+  } else {
+    def encode(s: String): String = URLEncoder.encode(s, "UTF-8")
+
+    url + queryString.flatMap { case (key: String, values: Seq[String]) =>
+      values.map { value =>
+        val encodedKey = encode(key)
+        val encodedValue = encode(value)
+        s"$encodedKey=$encodedValue"
+      }
+    }.mkString("?", "&", "")
+  }
+}

--- a/src/main/scala/mockws/FakeWSResponseHeaders.scala
+++ b/src/main/scala/mockws/FakeWSResponseHeaders.scala
@@ -1,0 +1,32 @@
+package mockws
+
+import play.api.libs.ws.WSResponseHeaders
+import play.api.mvc.{ResponseHeader, Result}
+
+case class FakeWSResponseHeaders(status: Int, headers: Map[String, Seq[String]]) extends WSResponseHeaders {
+
+  def this(result: Result) = this(result.header.status, FakeWSResponseHeaders.toMultiMap(result.header))
+}
+
+object FakeWSResponseHeaders {
+
+  /**
+   * Transition the response headers from {{{Map[String, String]}}} to {{{Map[String, Seq[String]]}}}.
+   *
+   * The closest behavior to the real WSClient implementations is wrap each value in a Seq() of size 1.
+   *
+   * Justification:
+   * Multiple header response values for a single key are legal per RFC 2616 4.2 in two forms.
+   *
+   * 1. Comma separated (e.g. Cache-Control: no-store, no-cache)
+   * NingWSClient represents these as Map("Cache-Control" -> Seq("no-store, "no-cache"))
+   * rather than splitting them, so we shall too.
+   *
+   * 2. Split into header key-value pairs (e.g. Cache-Control: no-store, Cache-Control: no-cache)
+   * Play 2.3 has a bug and is incapable of producing this response, so we don't have to worry about it.
+   * TL;DR: play.api.mvc.ResponseHeader uses a Map[String, String] which doesn't allow key collisions.
+   *
+   * See: https://github.com/playframework/playframework/issues/3544
+   */
+  def toMultiMap(header: ResponseHeader): Map[String, Seq[String]] = header.headers.mapValues(Seq(_))
+}

--- a/src/main/scala/mockws/MockWS.scala
+++ b/src/main/scala/mockws/MockWS.scala
@@ -1,27 +1,7 @@
 package mockws
 
-import java.io.ByteArrayInputStream
-import java.net.URLEncoder
-import java.nio.charset.{Charset, StandardCharsets}
-
-import com.ning.http.client.providers.netty.NettyResponse
-import org.mockito.BDDMockito._
-import org.mockito.Mockito._
-import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.Answer
-import play.api.http.{ContentTypeOf, Writeable}
-import play.api.libs.iteratee.{Enumerator, Iteratee}
-import play.api.libs.json.Json
-import play.api.libs.ws._
+import play.api.libs.ws.{WSClient, WSRequestHolder}
 import play.api.mvc.EssentialAction
-import play.api.test.FakeRequest
-import play.api.test.Helpers._
-
-import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import scala.reflect.ClassTag
-import scala.util.Try
 
 /**
  * Mock implementation for the [[play.api.libs.ws.WS]] client.
@@ -45,207 +25,18 @@ import scala.util.Try
  *   val ws = MockWS(index orElse hiWorld)
  * }}}
  *
- * @param withRoutes routes defining the mock calls
+ * @param routes routes defining the mock calls
  */
-case class MockWS(withRoutes: MockWS.Routes) extends WSClient {
-
-  require(withRoutes != null)
-
-  import mockws.MockWS.logger
+class MockWS(routes: MockWS.Routes) extends WSClient {
+  require(routes != null)
 
   override def underlying[T]: T = this.asInstanceOf[T]
 
-  private[this] val routes = (method: String, path: String) =>
-    if (withRoutes.isDefinedAt(method, path))
-      withRoutes.apply(method, path)
-    else
-      throw new Exception(s"no route defined for $method $path")
-
-  def url(url: String): WSRequestHolder = {
-
-    var method = GET
-    val requestHeaders = mutable.Buffer[(String, String)]()
-    val queryParameters = mutable.Map[String, String]()
-
-    def urlWithQueryParam(u: String) = if (queryParameters.isEmpty) {
-      u
-    } else {
-      val encode = (s: String) => URLEncoder.encode(s, "UTF-8")
-
-      u + queryParameters
-        .map { case (q: String, v: String) =>
-          val encodedQ = encode(q)
-          val encodedV = encode(v)
-          s"$encodedQ=$encodedV"
-        }
-        .mkString("?", "&", "")
-    }
-
-    def buildResponse(method: String): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = {
-
-      val _url = urlWithQueryParam(url)
-      val action: EssentialAction = routes.apply(method, _url)
-      logger.info(s"calling $method $url")
-      val fakeRequest = FakeRequest(method, _url).withHeaders(requestHeaders: _*)
-      val futureResult = action(fakeRequest).run
-      futureResult map { result =>
-        val wsResponseHeaders = new WSResponseHeaders {
-          override val status: Int = result.header.status
-          override val headers: Map[String, Seq[String]] = result.header.headers.mapValues(Seq(_))
-        }
-        (wsResponseHeaders, result.body)
-      }
-    }
-
-    def answerStream(method: => String) = new Answer[Future[(WSResponseHeaders, Enumerator[Array[Byte]])]] {
-      def answer(invocation: InvocationOnMock): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] =
-        buildResponse(method)
-    }
-
-    def answerIteratee(method: String) = new Answer[Future[Iteratee[Array[Byte], _]]] {
-      def answer(invocation: InvocationOnMock): Future[Iteratee[Array[Byte], _]] = {
-        val args = invocation.getArguments
-
-        buildResponse(method) flatMap { case (wsResponseHeaders, stream) =>
-          val consumer = args(0).asInstanceOf[WSResponseHeaders => Iteratee[Array[Byte], _]]
-          val it = consumer.apply(wsResponseHeaders)
-          stream.apply(it)
-        }
-      }
-    }
-
-    def wsRequestHolderAnswer(method: => String) = new Answer[Future[WSResponse]] {
-      def answer(invocation: InvocationOnMock): Future[WSResponse] = {
-        // request body
-        val action: EssentialAction = routes.apply(method, url)
-
-        val _url = urlWithQueryParam(url)
-        val args = invocation.getArguments
-        val futureResult = if (args.length == 3) {
-          // ws was called with a body content. Extract this content and send it to the mock backend.
-          val (bodyContent, mimeType) = extractBodyContent(args)
-          logger.info(s"calling $method $url with '${new String(bodyContent)}' (mimeType:'$mimeType')")
-          val requestBody = Enumerator(bodyContent) andThen Enumerator.eof
-          val fakeRequest = mimeType match {
-            case Some(m) => FakeRequest(method, _url).withHeaders(CONTENT_TYPE -> m).withHeaders(requestHeaders: _*)
-            case None => FakeRequest(method, _url).withHeaders(requestHeaders: _*)
-          }
-          requestBody |>>> action(fakeRequest)
-        } else {
-          logger.info(s"calling $method $url")
-          val fakeRequest = FakeRequest(method, _url).withHeaders(requestHeaders: _*)
-          action(fakeRequest).run
-        }
-
-        for {
-          result <- futureResult
-          contentAsBytes <- result.body |>>> Iteratee.consume[Array[Byte]]()
-        } yield {
-          val wsResponse = mock(classOf[WSResponse])
-          given (wsResponse.status) willReturn result.header.status
-          given (wsResponse.header(any)) willAnswer mockHeaders(result.header.headers)
-          given (wsResponse.allHeaders) willReturn result.header.headers.map { case(k, v) => k -> Seq(v) }
-          val bodyCharset = charset(result.header.headers).map(Charset.forName).getOrElse(StandardCharsets.UTF_8)
-          val body = new String(contentAsBytes, bodyCharset)
-          given (wsResponse.body) willReturn body
-
-          val returnedContentType = result.header.headers
-            .get(CONTENT_TYPE)
-            .flatMap { ct => Try(ct.split(";").take(1).mkString.trim).toOption }
-            .map(_.toLowerCase)
-
-          returnedContentType match {
-            case Some("text/json") | Some("application/json") => given(wsResponse.json) willReturn Json.parse(body)
-            case Some("text/xml") | Some("application/xml") => given(wsResponse.xml) willReturn scala.xml.XML.loadString(body)
-            case _ => // wsResponse.body is already set
-          }
-
-          // underlying netty response
-          val nettyResponse = mock(classOf[NettyResponse])
-          given (wsResponse.underlying) willReturn nettyResponse
-          given (nettyResponse.getResponseBody) willReturn body
-          given (nettyResponse.getResponseBodyAsStream) willReturn new ByteArrayInputStream(contentAsBytes)
-          given (nettyResponse.getResponseBodyAsBytes) willReturn contentAsBytes
-
-          wsResponse
-        }
-      }
-    }
-
-    val ws = mock(classOf[WSRequestHolder])
-    given (ws.withAuth(any, any, any)) willReturn ws
-    given (ws.withFollowRedirects(any)) willReturn ws
-    given (ws.withHeaders(any)) will new Answer[WSRequestHolder] {
-      override def answer(invocation: InvocationOnMock): WSRequestHolder = {
-        for (arg <- invocation.getArguments) {
-          requestHeaders ++= arg.asInstanceOf[Seq[(String, String)]]
-        }
-        ws
-      }
-    }
-    given (ws.withQueryString(any)) will new Answer[WSRequestHolder] {
-      override def answer(invocation: InvocationOnMock): WSRequestHolder = {
-        for (arg <- invocation.getArguments) {
-          queryParameters ++= arg.asInstanceOf[Seq[(String, String)]]
-        }
-        ws
-      }
-    }
-    given (ws.withRequestTimeout(any)) willReturn ws
-    given (ws.withVirtualHost(any)) willReturn ws
-    
-    given (ws.withMethod(any[String])) will new Answer[WSRequestHolder] {
-      override def answer(invocation: InvocationOnMock): WSRequestHolder = {
-        invocation.getArguments match {
-          case Array(m: String) => method = m
-        }
-        ws
-      }
-    }
-    
-    given (ws.execute()) will wsRequestHolderAnswer(method)
-    given (ws.sign(any)) willReturn ws
-
-    given (ws.get()) will wsRequestHolderAnswer(GET)
-    given (ws.get(any)(any)) will answerIteratee(GET)
-    given (ws.post(any[AnyRef])(any, any)) will wsRequestHolderAnswer(POST)
-    given (ws.put(any[AnyRef])(any, any)) will wsRequestHolderAnswer(PUT)
-    given (ws.patch(any[AnyRef])(any, any)) will wsRequestHolderAnswer("PATCH")
-    given (ws.delete()) will wsRequestHolderAnswer(DELETE)
-
-    given (ws.stream()) will answerStream(method)
-    given (ws.getStream()) will answerStream(GET)
-
-    ws
-  }
-
-  private def any[T : ClassTag]: T = org.mockito.Matchers.any(implicitly[ClassTag[T]].runtimeClass).asInstanceOf[T]
-
-  private[this] def extractBodyContent[T](args: Array[Object]): (Array[Byte], Option[String]) = {
-    val bodyObject = args(0).asInstanceOf[T]
-    val writeable = args(1).asInstanceOf[Writeable[T]]
-    val contentTypeOf = args(2).asInstanceOf[ContentTypeOf[T]]
-    val mimeType = contentTypeOf.mimeType
-    (writeable.transform(bodyObject), mimeType)
-  }
-
-  private[this] def mockHeaders(headers: Map[String, String]) = new Answer[Option[String]] {
-    def answer(invocation: InvocationOnMock): Option[String] = {
-      val args = invocation.getArguments
-      val key = args(0).asInstanceOf[String]
-      headers.get(key)
-    }
-  }
-
-  private[this] def charset(headers: Map[String, String]): Option[String] = headers.get(CONTENT_TYPE) match {
-    case Some(s) if s.contains("charset=") => Some(s.split("; charset=").drop(1).mkString.trim)
-    case _ => None
-  }
-
+  override def url(url: String): WSRequestHolder = new FakeWSRequestHolder(routes, url)
 }
 
 object MockWS {
   type Routes = PartialFunction[(String, String), EssentialAction]
 
-  private val logger = play.api.Logger("mockws.MockWS")
+  def apply(routes: Routes) = new MockWS(routes)
 }

--- a/src/main/scala/mockws/TimeoutProvider.scala
+++ b/src/main/scala/mockws/TimeoutProvider.scala
@@ -1,0 +1,69 @@
+package mockws
+
+import java.util.concurrent._
+
+import play.core.NamedThreadFactory
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{Future, Promise}
+
+trait TimeoutProvider {
+
+  /**
+   * Times out the future after the specified delay.
+   */
+  def timeout[T](future: Future[T], delay: FiniteDuration, timeoutMsg: String): Future[T]
+}
+
+object SchedulerExecutorServiceTimeoutProvider extends TimeoutProvider {
+
+  /**
+   * A scheduler backed by a thread-pool that spins down threads when no longer in use.
+   *
+   * Unless explicitly set to fork, "sbt test" creates a new one of these
+   * thread pools every run and doesn't bother to tear them down.
+   *
+   * Cleaning up after ourselves is necessary to avoid leaking threads.
+   */
+  private lazy val scheduler: ScheduledExecutorService = {
+    val executor = new ScheduledThreadPoolExecutor(1, new DaemonizingThreadFactory)
+    executor.setKeepAliveTime(5, TimeUnit.SECONDS)
+    executor.allowCoreThreadTimeOut(true)
+    executor
+  }
+
+  def timeout[T](future: Future[T], delay: FiniteDuration, msg: String): Future[T] = {
+    val p = Promise[T]()
+
+    // happy path
+    p tryCompleteWith future
+
+    // set the timeout
+    val timeoutTask = scheduler.schedule(
+      new Runnable {
+        override def run(): Unit = p tryFailure new TimeoutException(msg)
+      }, delay.length, delay.unit
+    )
+
+    // If the future completes before the timeout, unschedule the timeout so the scheduler is free to spin down.
+    // This is relevant for application code under test that sets long timeouts which aren't expected to be met.
+    future.onComplete(_ => timeoutTask.cancel(false))
+
+    p.future
+  }
+
+  /**
+   * If for some reason, people use this library in non-test code, then scheduled timeouts
+   * shouldn't prevent JVM termination if it would otherwise exit normally.
+   */
+  class DaemonizingThreadFactory(underlying: ThreadFactory = new NamedThreadFactory(getClass.getSimpleName)) extends ThreadFactory {
+
+    override def newThread(r: Runnable): Thread = {
+      val thread = underlying.newThread(r)
+      thread.setDaemon(true)
+      thread
+    }
+  }
+
+}

--- a/src/test/scala/mockws/CookieTest.scala
+++ b/src/test/scala/mockws/CookieTest.scala
@@ -1,0 +1,38 @@
+package mockws
+
+import org.scalatest.{FunSuite, Matchers}
+import play.api.mvc.{Cookie, Action}
+import play.api.mvc.Results._
+import play.api.test.Helpers._
+
+class CookieTest extends FunSuite with Matchers {
+
+  test("A cookie can be returned from an action") {
+    val ws = MockWS {
+      case (_, _) => Action(
+        NoContent.withCookies(
+          Cookie(
+            name = "session_id",
+            value = "1",
+            maxAge = Some(3600),
+            path = "/account",
+            domain = Some("https://www.example.com"),
+            secure = true
+          )
+        )
+      )
+    }
+
+    val response = await(ws.url("/").get())
+
+    response.cookies should have size 1
+
+    response.cookie("session_id").get should have(
+      'value (Some("1")),
+      'maxAge (Some(3600)),
+      'path ("/account"),
+      'domain ("https://www.example.com"),
+      'secure (true)
+    )
+  }
+}

--- a/src/test/scala/mockws/FakeAchResponseTest.scala
+++ b/src/test/scala/mockws/FakeAchResponseTest.scala
@@ -1,0 +1,76 @@
+package mockws
+
+import org.apache.commons.io.IOUtils
+import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.iteratee.Enumerator
+import play.api.mvc.{ResponseHeader, Result}
+
+class FakeAchResponseTest extends FunSpec with Matchers {
+
+  describe("typical 200 response") {
+    val bodyString = "response body"
+    val charset = "utf-8"
+    val bodyBytes = bodyString.getBytes(charset)
+    val contentType = s"text/plain; charset=$charset"
+
+    val response = buildFakeAchResponse(
+      status = 200,
+      headers = Map("Content-Type" -> contentType),
+      body = bodyBytes
+    )
+
+    it("returns expected values for all methods") {
+      response.getResponseBodyAsByteBuffer.array() shouldBe bodyBytes
+
+      response.getResponseBodyExcerpt(0) shouldBe ""
+      response.getResponseBodyExcerpt(1) shouldBe "r"
+
+      response.getResponseBodyExcerpt(0, null) shouldBe ""
+      response.getResponseBodyExcerpt(1, null) shouldBe "r"
+
+      response.getStatusCode shouldBe 200
+
+      response.getResponseBodyAsBytes shouldBe bodyBytes
+
+      IOUtils.toByteArray(response.getResponseBodyAsStream) shouldBe bodyBytes
+
+      response.isRedirected shouldBe false
+
+      response.getCookies shouldBe empty
+
+      response.getHeader("Content-Type") shouldBe contentType
+      response.getHeader("invalid") shouldBe null
+
+      response.getHeaders should have size 1
+
+      response.getStatusCode shouldBe 200
+
+      response.getStatusText shouldBe "200 OK"
+
+      response.hasResponseHeaders shouldBe true
+
+      response.getResponseBody(charset) shouldBe bodyString
+
+      response.getResponseBody shouldBe bodyString
+
+      response.hasResponseBody shouldBe true
+
+      response.getContentType shouldBe contentType
+
+      response.hasResponseStatus shouldBe true
+
+      a[NotImplementedError] shouldBe thrownBy(response.getUri)
+    }
+  }
+
+  private def buildFakeAchResponse(
+    status: Int = 200,
+    headers: Map[String, String] = Map.empty,
+    body: Array[Byte] = Array.empty
+    ) = {
+    new FakeAhcResponse(
+      result = new Result(new ResponseHeader(status, headers), Enumerator(body)),
+      body = body
+    )
+  }
+}

--- a/src/test/scala/mockws/ResponseHeaderTest.scala
+++ b/src/test/scala/mockws/ResponseHeaderTest.scala
@@ -1,0 +1,38 @@
+package mockws
+
+import org.scalatest.{FunSuite, Matchers}
+import play.api.mvc.Action
+import play.api.mvc.Results._
+import play.api.test.Helpers._
+
+/**
+ * Tests RFC-2616 4.2:
+ *
+ * {{{
+ * Multiple message-header fields with the same field-name MAY be present in a
+ * message if and only if the entire field-value for that header field is
+ * defined as a comma-separated list [i.e., #(values)].
+ *
+ * It MUST be possible to combine the multiple header fields into one
+ * "field-name: field-value" pair, without changing the semantics of the message,
+ * by appending each subsequent field-value to the first, each separated by a comma.
+ *
+ * The order in which header fields with the same field-name are received is therefore
+ * significant to the interpretation of the combined field value, and thus a proxy
+ * MUST NOT change the order of these field values when a message is forwarded.
+ * }}}
+ *
+ * Due to a bug in play, we can't fully support this. https://github.com/playframework/playframework/issues/3544
+ */
+class ResponseHeaderTest extends FunSuite with Matchers {
+
+  test("Multiple response headers with comma separated values should be returned unmodified") {
+    val ws = MockWS {
+      case (_, _) => Action(NoContent.withHeaders("Cache-Control" -> "no-cache, no-store"))
+    }
+
+    val headerValues = await(ws.url("/").get()).allHeaders("Cache-Control")
+    headerValues should have size 1
+    headerValues.head shouldBe "no-cache, no-store"
+  }
+}

--- a/src/test/scala/mockws/TimeoutTest.scala
+++ b/src/test/scala/mockws/TimeoutTest.scala
@@ -1,0 +1,28 @@
+package mockws
+
+import java.util.concurrent.TimeoutException
+
+import org.scalatest.concurrent.ScalaFutures._
+import org.scalatest.time.{Milliseconds, Span}
+import org.scalatest.{FunSuite, Matchers}
+import play.api.mvc.{Action, Result}
+
+import scala.concurrent.Promise
+
+class TimeoutTest extends FunSuite with Matchers {
+
+  /**
+   * Given a route that hangs forever, a request timeout of 1 ms should fail the future within 500 ms.
+   */
+  test("request timeout should fail calls that don't complete") {
+    implicit val patienceConfig = PatienceConfig(timeout = Span(500, Milliseconds))
+
+    val ws = MockWS {
+      case (_, "/hang/forever") => Action.async(Promise[Result]().future)
+    }
+
+    val futureResponse = ws.url("/hang/forever").withRequestTimeout(1).get()
+
+    whenReady(futureResponse.failed)(_ shouldBe a[TimeoutException])
+  }
+}


### PR DESCRIPTION
> Implementing WSRequest instead of using a mock would ensure that we do not forget any methods.
It is a good idea, but quite a rewrite of the actual code.

This PR resolves #8 by replacing mockito with a concrete implementation. MockWS definitely will not produce NPEs from missing stubs anymore!

I added a bit more test coverage and also implemented request timeouts. All existing tests pass locally without any modification.