### PR TITLE
Fix truncated response in FakeWSRequestHolder

### DIFF
--- a/src/main/scala/mockws/FakeWSRequestHolder.scala
+++ b/src/main/scala/mockws/FakeWSRequestHolder.scala
@@ -81,9 +81,8 @@ case class FakeWSRequestHolder(
   def execute(): Future[WSResponse] =
     for {
       result <- executeResult()
-      responseBodyBytes ←
-        result.body.dataStream.runWith(Sink.headOption).map(_.fold(Array.empty[Byte])(_.toArray))
-    } yield new AhcWSResponse(new FakeAhcResponse(result, responseBodyBytes))
+      responseBody ← result.body.dataStream.runFold(ByteString.empty)(_ ++ _)
+    } yield new AhcWSResponse(new FakeAhcResponse(result, responseBody.toArray))
 
 
   def stream(): Future[StreamedResponse] =

--- a/src/test/scala/mockws/MockWSTest.scala
+++ b/src/test/scala/mockws/MockWSTest.scala
@@ -341,4 +341,22 @@ class MockWSTest extends FunSuite with Matchers with PropertyChecks {
       .get()).body shouldEqual "get ok"
     ws.close()
   }
+
+  test("should pass through all elements of a Source") {
+    val content = Source(Seq("hello, ", "world").map(ByteString(_)))
+
+    val ws = MockWS {
+      case (GET, "/get") ⇒ Action {
+        Result(
+          header = ResponseHeader(200),
+          body = HttpEntity.Streamed(content, None, None)
+        )
+      }
+    }
+
+    await(ws
+      .url("/get")
+      .get()).body shouldEqual "hello, world"
+    ws.close()
+  }
 }


### PR DESCRIPTION
A `Result.body.dataStream` is a `Source[ByteString, _]` which generates
a stream of ByteString elements.

Using a `Sink.headOption` in runWith only processes the first (optional)
element and ignores all subsequent elements.

When using a MockWS with `Ok.sendFile` in a specification, the
controller using the `WSRequest` only received the first 8192 Bytes of
the given file because of this.

Concatenate all generated `ByteString`s and use that as responseBody.