### PR TITLE
add support for HTTP Authentication: Basic - Fixes #12

### DIFF
--- a/src/test/scala/mockws/MockWSTest.scala
+++ b/src/test/scala/mockws/MockWSTest.scala
@@ -8,10 +8,10 @@ import org.scalatest.{FunSuite, Matchers}
 import play.api.http.HttpEntity
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.iteratee.Concurrent._
-import play.api.libs.iteratee.{Enumerator, Iteratee}
+import play.api.libs.iteratee.Iteratee
 import play.api.libs.json.Json
 import play.api.libs.streams.Streams
-import play.api.libs.ws.{WSResponseHeaders, WSAuthScheme, WSClient, WSSignatureCalculator}
+import play.api.libs.ws.{WSAuthScheme, WSClient, WSResponseHeaders, WSSignatureCalculator}
 import play.api.mvc.BodyParsers.parse
 import play.api.mvc.Results._
 import play.api.mvc.{Action, ResponseHeader, Result}
@@ -323,6 +323,42 @@ class MockWSTest extends FunSuite with Matchers with PropertyChecks {
     contentAsString(response) shouldEqual "firstsecondthird"
     header("x-header", response) shouldEqual Some("x-value")
     ws.close()
+  }
+
+
+  test("mock WS supports authentication with Basic Auth") {
+
+    val BasicAuth = "Basic: ((?:[A-Za-z0-9+/]{4})+(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)".r
+
+    val ws = MockWS {
+      case (_, _) => Action { request =>
+        request.headers.get(AUTHORIZATION) match {
+          case Some(BasicAuth("dXNlcjpzM2NyM3Q=")) => Ok
+          case _ => Unauthorized
+        }
+      }
+    }
+
+    val wsResponseOk = await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.BASIC).get)
+    wsResponseOk.status shouldEqual OK
+
+    val wsResponseUnauthorized = await(ws.url("/").withAuth("user", "secret", WSAuthScheme.BASIC).get)
+    wsResponseUnauthorized.status shouldEqual UNAUTHORIZED
+
+    ws.close()
+
+  }
+
+
+  test("mock WS does not support authentication with `WSAuthScheme.{NTLM, DIGEST, KERBEROS, SPNEGO}`") {
+
+    val ws = MockWS { case (_, _) => Action { request => Ok } }
+
+    a [UnsupportedOperationException] shouldBe thrownBy (await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.NTLM).get))
+    a [UnsupportedOperationException] shouldBe thrownBy (await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.DIGEST).get))
+    a [UnsupportedOperationException] shouldBe thrownBy (await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.KERBEROS).get))
+    a [UnsupportedOperationException] shouldBe thrownBy (await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.SPNEGO).get))
+
   }
 
 


### PR DESCRIPTION
This PR enables usage of `withAuth` on `MockWS` object.
The 'Authorization' header is set according to RFC 2617,
Section 2 [1] 'Basic Authentication Scheme'.

Other schemata are not supported.

The (positive) test case is based on work of @Manc and
implementation of @yanns [2].

[1] https://tools.ietf.org/html/rfc2617#section-2
[2] https://github.com/leanovate/play-mockws/issues/12#issuecomment-204978719