### PR TITLE
No shutdown hook when using trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,12 @@ From the 2.6 version, it is recommended that your tests either extend trait Mock
 provides an implicit Materializer you need when working with Play's Actions.
 
 ```scala
-class MySpec extends FreeSpec with Matchers with MockWSHelpers {
+class MySpec extends FreeSpec with Matchers with MockWSHelpers with BeforeAndAfterAll {
   ...
+
+  override def afterAll(): Unit = {
+    shutdownHelpers()
+  }
 }
 ```
 

--- a/src/main/scala/mockws/MockWSHelpers.scala
+++ b/src/main/scala/mockws/MockWSHelpers.scala
@@ -14,6 +14,7 @@ import scala.concurrent.duration._
   * use MockWS and its Action { ... } definitions inside your testclasses.
   *
   * Mix this trait into the tests where you use MockWS.
+  * WARNING: you have to call `shutdownHelpers()` after usage to avoid memory leaks.
   *
   * You can also use the object if you dislike traits and like to instead import the functionality.
   *

--- a/src/test/scala/mockws/AuthenticationTest.scala
+++ b/src/test/scala/mockws/AuthenticationTest.scala
@@ -1,5 +1,6 @@
 package mockws
 
+import mockws.MockWSHelpers._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSuite, Matchers}
 import play.api.libs.ws.WSAuthScheme
@@ -9,7 +10,7 @@ import play.api.test.Helpers._
 /**
  * Tests that [[MockWS]] simulates a WS client, in particular the methods involving authentication
  */
-class AuthenticationTest extends FunSuite with Matchers with PropertyChecks with MockWSHelpers {
+class AuthenticationTest extends FunSuite with Matchers with PropertyChecks {
 
   test("mock WS supports authentication with Basic Auth") {
 

--- a/src/test/scala/mockws/Example.scala
+++ b/src/test/scala/mockws/Example.scala
@@ -1,11 +1,12 @@
 package mockws
 
+import mockws.MockWSHelpers._
 import org.scalatest.{FreeSpec, Matchers, OptionValues}
-import scala.concurrent.ExecutionContext.Implicits._
 import play.api.libs.ws.WSClient
 import play.api.mvc.Results._
 import play.api.test.Helpers._
 
+import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 import scala.util.Try
 
@@ -54,7 +55,7 @@ trait TestScope {
 }
 
 
-class Example extends FreeSpec with Matchers with OptionValues with MockWSHelpers {
+class Example extends FreeSpec with Matchers with OptionValues {
 
   // and we can test the implementation of GatewayToTest
 

--- a/src/test/scala/mockws/FakeAchResponseTest.scala
+++ b/src/test/scala/mockws/FakeAchResponseTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FunSpec, Matchers}
 import play.api.http.HttpEntity.Strict
 import play.api.mvc.{ResponseHeader, Result}
 
-class FakeAchResponseTest extends FunSpec with Matchers with MockWSHelpers {
+class FakeAchResponseTest extends FunSpec with Matchers {
 
   describe("typical 200 response") {
     val bodyString = "response body"

--- a/src/test/scala/mockws/MockWSTest.scala
+++ b/src/test/scala/mockws/MockWSTest.scala
@@ -2,19 +2,15 @@ package mockws
 
 import java.net.InetSocketAddress
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import mockws.MockWSHelpers._
 import org.mockito.Mockito._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSuite, Matchers}
-import play.api.http.HttpEntity
 import play.api.libs.json.Json
-import play.api.libs.ws.{WSAuthScheme, WSClient, WSResponse, WSSignatureCalculator}
-import play.api.mvc.Results._
+import play.api.libs.ws.{WSAuthScheme, WSResponse, WSSignatureCalculator}
 import play.api.mvc.Result
+import play.api.mvc.Results._
 import play.api.test.Helpers._
-import play.libs.ws.WSRequest
-import play.shaded.ahc.org.asynchttpclient.Response
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
@@ -23,7 +19,7 @@ import scala.concurrent.duration._
 /**
  * Tests that [[MockWS]] simulates a WS client
  */
-class MockWSTest extends FunSuite with Matchers with PropertyChecks with MockWSHelpers {
+class MockWSTest extends FunSuite with Matchers with PropertyChecks {
 
   test("mock WS simulates all HTTP methods") {
     val ws = MockWS {

--- a/src/test/scala/mockws/ResponseHeaderTest.scala
+++ b/src/test/scala/mockws/ResponseHeaderTest.scala
@@ -1,5 +1,6 @@
 package mockws
 
+import mockws.MockWSHelpers._
 import org.scalatest.{FunSuite, Matchers}
 import play.api.mvc.Results._
 import play.api.test.Helpers._
@@ -23,7 +24,7 @@ import play.api.test.Helpers._
  *
  * Due to a bug in play, we can't fully support this. https://github.com/playframework/playframework/issues/3544
  */
-class ResponseHeaderTest extends FunSuite with Matchers with MockWSHelpers {
+class ResponseHeaderTest extends FunSuite with Matchers {
 
   test("Multiple response headers with comma separated values should be returned unmodified") {
     val ws = MockWS {

--- a/src/test/scala/mockws/RouteTest.scala
+++ b/src/test/scala/mockws/RouteTest.scala
@@ -2,6 +2,7 @@ package mockws
 
 import java.util.concurrent.{Executors, TimeUnit}
 
+import mockws.MockWSHelpers._
 import org.scalatest.{FunSuite, Matchers}
 import play.api.mvc.Results._
 import play.api.test.Helpers._
@@ -9,7 +10,7 @@ import play.api.test.Helpers._
 /**
  * Tests [[Route]]
  */
-class RouteTest extends FunSuite with Matchers with MockWSHelpers {
+class RouteTest extends FunSuite with Matchers {
 
   test("a route knows if it was called") {
     val route1 = Route {

--- a/src/test/scala/mockws/StreamingTest.scala
+++ b/src/test/scala/mockws/StreamingTest.scala
@@ -2,10 +2,10 @@ package mockws
 
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import mockws.MockWSHelpers._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSuite, Matchers}
 import play.api.http.HttpEntity
-import scala.concurrent.ExecutionContext.Implicits._
 import play.api.libs.ws.WSClient
 import play.api.mvc.MultipartFormData.DataPart
 import play.api.mvc.{ResponseHeader, Result}
@@ -13,11 +13,12 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
 import scala.collection.immutable.Seq
+import scala.concurrent.ExecutionContext.Implicits._
 
 /**
   * Tests that [[MockWS]] simulates a WS client, in particular the methods involving authentication
   */
-class StreamingTest extends FunSuite with Matchers with PropertyChecks with MockWSHelpers {
+class StreamingTest extends FunSuite with Matchers with PropertyChecks {
 
   test("mock WS simulates a streaming") {
 

--- a/src/test/scala/mockws/TimeoutTest.scala
+++ b/src/test/scala/mockws/TimeoutTest.scala
@@ -4,13 +4,13 @@ import java.util.concurrent.TimeoutException
 
 import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.time.{Milliseconds, Span}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 import play.api.mvc.Result
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-class TimeoutTest extends FunSuite with Matchers with MockWSHelpers {
+class TimeoutTest extends FunSuite with Matchers with MockWSHelpers with BeforeAndAfterAll {
 
   /**
    * Given a route that hangs forever, a request timeout of 1 ms should fail the future within 500 ms.
@@ -28,4 +28,9 @@ class TimeoutTest extends FunSuite with Matchers with MockWSHelpers {
 
     ws.close()
   }
+
+  override def afterAll(): Unit = {
+    shutdownHelpers()
+  }
+
 }


### PR DESCRIPTION
The shutdown hook should only be used when using the helpers objects.

The helpers trait provide a shutdown function that can be used
by after all hook from test frameworks.