### PR TITLE
Update README.md: latest version is 2.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add MockWS as test dependency in the `build.sbt`:
 
 * for Play 2.6.x:
 ```scala
-libraryDependencies += "de.leanovate.play-mockws" %% "play-mockws" % "2.6.0" % Test
+libraryDependencies += "de.leanovate.play-mockws" %% "play-mockws" % "2.6.2" % Test
 ```
 * for Play 2.5.x:
 ```scala


### PR DESCRIPTION
Currently, README is very confusing, because 2.6.0 doesn't have `MockWSHelpers`, better update docs to mention the latest version.