### PR TITLE
Fix withHttpHeaders behavior for FakeWSRequestHolder

### DIFF
--- a/src/main/scala/mockws/FakeWSRequestHolder.scala
+++ b/src/main/scala/mockws/FakeWSRequestHolder.scala
@@ -66,7 +66,7 @@ case class FakeWSRequestHolder(
   def withHeaders(hdrs: (String, String)*): Self = withHttpHeaders(hdrs: _*)
 
   def withHttpHeaders(hdrs: (String, String)*): Self = {
-    val headers = hdrs.foldLeft(this.headers)(
+    val headers = hdrs.foldLeft(Map.empty[String, Seq[String]])(
       (m, hdr) =>
         if (m.contains(hdr._1)) m.updated(hdr._1, m(hdr._1) :+ hdr._2)
         else m + (hdr._1 -> Seq(hdr._2))

--- a/src/test/scala/mockws/MockWSTest.scala
+++ b/src/test/scala/mockws/MockWSTest.scala
@@ -282,4 +282,22 @@ class MockWSTest extends FunSuite with Matchers with PropertyChecks {
 
     ws.close()
   }
+
+  test("discard old headers when setting withHttpHeaders") {
+    var headers: Map[String, scala.Seq[String]] = Map.empty
+    val ws = MockWS {
+      case (GET, "/get") => Action {
+        req =>
+          headers = req.headers.toMap
+          Ok(req.headers.getAll("key1").zipWithIndex.toString) }
+    }
+    val request = ws.url("/get")
+      .withHttpHeaders("key1" -> "value1")
+      .withHttpHeaders("key2" -> "value2")
+      .get()
+
+    await(request)
+    headers.get("key1") shouldBe None
+    headers.get("key2") shouldBe Some(Seq("value2"))
+  }
 }


### PR DESCRIPTION
When calling this method old headers are discarded

Here's a corresponding test in play-ws: https://github.com/playframework/play-ws/blob/master/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala#L212