### PR TITLE
Fix withQueryStringParameters behavior for FakeWSRequestHolder

### DIFF
--- a/src/main/scala/mockws/FakeWSRequestHolder.scala
+++ b/src/main/scala/mockws/FakeWSRequestHolder.scala
@@ -77,7 +77,7 @@ case class FakeWSRequestHolder(
   def withQueryString(parameters: (String, String)*): Self = withQueryStringParameters(parameters: _*)
 
   def withQueryStringParameters(parameters: (String, String)*): Self = copy(
-    queryString = parameters.foldLeft(queryString) {
+    queryString = parameters.foldLeft(Map.empty[String, Seq[String]]) {
       case (m, (k, v)) => m + (k -> (v +: m.getOrElse(k, Nil)))
     }
   )

--- a/src/test/scala/mockws/MockWSTest.scala
+++ b/src/test/scala/mockws/MockWSTest.scala
@@ -300,4 +300,23 @@ class MockWSTest extends FunSuite with Matchers with PropertyChecks {
     headersMap.get("key1") shouldBe None
     headersMap.get("key2") shouldBe Some(Seq("value2"))
   }
+
+  test("discard old query parameters when setting withQueryStringParameters") {
+    val queryString = new AtomicReference[Map[String, scala.Seq[String]]](Map.empty)
+    val ws = MockWS {
+      case (GET, "/get") => Action {
+        req =>
+          queryString.set(req.queryString)
+          Ok("") }
+    }
+    val request = ws.url("/get")
+      .withQueryStringParameters("bar" -> "baz")
+      .withQueryStringParameters("bar" -> "bah")
+      .get()
+
+    await(request)
+    val queryMap = queryString.get()
+    queryMap.get("bar") shouldBe Some(Seq("bah"))
+  }
+
 }


### PR DESCRIPTION
When calling this method old query parameters are discarded
Test in play-ws: https://github.com/playframework/play-ws/blob/b212e73188b894fd474522e5dd7773feab164a89/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala#L67