### PR TITLE
return 404 for route not found

### DIFF
--- a/src/main/scala/mockws/FakeWSRequestHolder.scala
+++ b/src/main/scala/mockws/FakeWSRequestHolder.scala
@@ -108,10 +108,7 @@ case class FakeWSRequestHolder(
 
   private def executeResult(): Future[Result] = {
     logger.debug(s"calling $method $url")
-    def fakeRequest =
-      FakeRequest(method, urlWithQueryParams())
-        .withHeaders(headersSeq(): _*)
-        .withBody(body)
+    def fakeRequest = FakeRequest(method, urlWithQueryParams()).withHeaders(headersSeq(): _*).withBody(body)
     routes
       .lift((method, url)) match {
       case Some(action) =>

--- a/src/main/scala/mockws/MockWS.scala
+++ b/src/main/scala/mockws/MockWS.scala
@@ -33,7 +33,7 @@ import play.api.mvc.Results.NotFound
  *
  * @param routes routes defining the mock calls
  */
-class MockWS(routes: MockWS.Routes, shutdownHook: () ⇒ Unit)(implicit val materializer: ActorMaterializer, action: RouteNotDefined) extends WSClient {
+class MockWS(routes: MockWS.Routes, shutdownHook: () ⇒ Unit)(implicit val materializer: ActorMaterializer, notFoundBehaviour: RouteNotDefined) extends WSClient {
   require(routes != null)
 
   override def underlying[T]: T = this.asInstanceOf[T]
@@ -51,7 +51,7 @@ object MockWS {
   /**
     * @param routes simulation of the external web resource
     */
-  def apply(routes: Routes)(implicit fn: RouteNotDefined) = {
+  def apply(routes: Routes)(implicit notFoundBehaviour: RouteNotDefined) = {
     implicit val system = ActorSystem("mock-ws-" + UUID.randomUUID().toString)
     implicit val materializer = ActorMaterializer()
     new MockWS(routes, () ⇒ system.terminate())
@@ -61,7 +61,7 @@ object MockWS {
     * @param routes       simulation of the external web resource
     * @param materializer user-defined materializer
     */
-  def apply(routes: Routes, materializer: ActorMaterializer)(implicit fn: RouteNotDefined) = {
+  def apply(routes: Routes, materializer: ActorMaterializer)(implicit notFoundBehaviour: RouteNotDefined) = {
     implicit val mat= materializer
     new MockWS(routes, () ⇒ Unit){}
   }
@@ -71,7 +71,7 @@ object MockWS {
 trait RouteNotDefined extends (() => Future[Result])
 object RouteNotDefined {
 
-  implicit val defaultAction:RouteNotDefined = RouteNotDefined(NotFound)
+  implicit val defaultAction: RouteNotDefined = RouteNotDefined(NotFound)
 
   def apply(result: Result): RouteNotDefined = new RouteNotDefined {
     override def apply(): Future[Result] = Future.successful(result)

--- a/src/test/scala/mockws/MockWSTest.scala
+++ b/src/test/scala/mockws/MockWSTest.scala
@@ -13,6 +13,7 @@ import play.api.mvc.Results._
 import play.api.test.Helpers._
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
+import scala.util._
 import scala.concurrent.duration._
 
 /**
@@ -131,14 +132,16 @@ class MockWSTest extends FunSuite with Matchers with PropertyChecks {
     val ws = MockWS {
       case (GET, "/url") => Action { Ok("") }
     }
+    import scala.concurrent.ExecutionContext.Implicits.global
+    ws.url("/url2").get() onComplete {
+      case Success(x)=> x.status should be(404)
+      case Failure(x)=> fail("should not throw an exception for url not found")
+    }
 
-    the [Exception] thrownBy {
-      ws.url("/url2").get()
-    } should have message "no route defined for GET /url2"
-
-    the [Exception] thrownBy {
-      ws.url("/url").delete()
-    } should have message "no route defined for DELETE /url"
+    ws.url("/url").delete() onComplete {
+      case Success(x)=> x.status should be(404)
+      case Failure(x)=> fail("should not throw an exception for url not found")
+    }
     ws.close()
   }
 


### PR DESCRIPTION
 If there is no route, that means the future is successful but the server returned 404
If we think of it as an exception with failed future then it will suppress the semantics of
client failure vs HTTP failures. Caller should check for HTTP status rather than future state