### PR TITLE
Use `addHttpHeaders` in `withBodyAndContentType`

### DIFF
--- a/src/main/scala/mockws/FakeWSRequestHolder.scala
+++ b/src/main/scala/mockws/FakeWSRequestHolder.scala
@@ -221,7 +221,7 @@ case class FakeWSRequestHolder(
     if (headers.contains("Content-Type")) {
       withBody(wsBody)
     } else {
-      withBody(wsBody).withHttpHeaders("Content-Type" -> contentType)
+      withBody(wsBody).addHttpHeaders("Content-Type" -> contentType)
     }
   }
 }

--- a/src/test/scala/mockws/MockWSTest.scala
+++ b/src/test/scala/mockws/MockWSTest.scala
@@ -319,4 +319,21 @@ class MockWSTest extends FunSuite with Matchers with PropertyChecks {
     queryMap.get("bar") shouldBe Some(Seq("bah"))
   }
 
+  test("keep headers with content type from BodyWritable") {
+    val headers = new AtomicReference[Map[String, scala.Seq[String]]](Map.empty)
+    val ws = MockWS {
+      case (POST, "/") => Action {
+        req =>
+          headers.set(req.headers.toMap)
+          Ok }
+    }
+    val request = ws.url("/")
+      .withHttpHeaders("key1" -> "value1")
+      .post("test")
+
+    val response = await(request)
+    response.status shouldBe OK
+    val headersMap = headers.get()
+    headersMap.get("key1") shouldBe Some(Seq("value1"))
+  }
 }


### PR DESCRIPTION
This fixes a regression introduced in commit
26aec991f50a7226dc4df76495dd546a8045b712 after which `withHttpHeaders` discards
old headers.

This causes all headers to vanish if you sent a body with the request.