### PR TITLE
Remove colon after 'Basic' in basic auth

### DIFF
--- a/src/main/scala/mockws/FakeWSRequestHolder.scala
+++ b/src/main/scala/mockws/FakeWSRequestHolder.scala
@@ -121,7 +121,7 @@ case class FakeWSRequestHolder(
     case Some((username, password, WSAuthScheme.BASIC)) ⇒
       val encoded = new String(
         Base64.getMimeEncoder().encode(s"$username:$password".getBytes("UTF-8")), "UTF-8")
-      req.withHeaders("Authorization" → s"Basic: $encoded")
+      req.withHeaders("Authorization" → s"Basic $encoded")
     case Some((_, _, unsupported)) ⇒ throw new UnsupportedOperationException(
       s"""do not support auth method $unsupported.
         |Help us to provide support for this.

--- a/src/test/scala/mockws/AuthenticationTest.scala
+++ b/src/test/scala/mockws/AuthenticationTest.scala
@@ -14,7 +14,7 @@ class AuthenticationTest extends FunSuite with Matchers with PropertyChecks {
 
   test("mock WS supports authentication with Basic Auth") {
 
-    val BasicAuth = "Basic: ((?:[A-Za-z0-9+/]{4})+(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)".r
+    val BasicAuth = "Basic ((?:[A-Za-z0-9+/]{4})+(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)".r
 
     val ws = MockWS {
       case (_, _) => Action { request =>


### PR DESCRIPTION
I believe there shouldn't be a colon after `Basic` in the auth header