### PR TITLE
Correct typo in documentation

### DIFF
--- a/src/main/scala/mockws/FakeWSResponseHeaders.scala
+++ b/src/main/scala/mockws/FakeWSResponseHeaders.scala
@@ -19,7 +19,7 @@ object FakeWSResponseHeaders {
    * Multiple header response values for a single key are legal per RFC 2616 4.2 in two forms.
    *
    * 1. Comma separated (e.g. Cache-Control: no-store, no-cache)
-   * NingWSClient represents these as Map("Cache-Control" -> Seq("no-store, "no-cache"))
+   * NingWSClient represents these as Map("Cache-Control" -> Seq("no-store, no-cache"))
    * rather than splitting them, so we shall too.
    *
    * 2. Split into header key-value pairs (e.g. Cache-Control: no-store, Cache-Control: no-cache)


### PR DESCRIPTION
Given the documentation discusses a Seq of size 1 I'm assuming the correction to avoid confusion is to remove the additional `"` and make the Seq a valid single string rather than adding an additional `"` and making it 2 strings?