### PR TITLE
Update scalafmt-core to 2.5.2

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -13,4 +13,4 @@ rewriteTokens = {
 }
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
-version = 2.3.2
+version = 2.5.2

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,9 +1,15 @@
-align = true
+align.preset = true
 assumeStandardLibraryStripMargin = true
-danglingParentheses = true
+danglingParentheses.preset = true
 docstrings = JavaDoc
 maxColumn = 120
 project.git = true
+
+newlines { 
+  alwaysBeforeMultilineDef = false
+  implicitParamListModifierPrefer = before
+}
+
 rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifiers, PreferCurlyFors ]
 rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abstract", "implicit", "override", "lazy" ]
 rewriteTokens = {

--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,9 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest"  %% "scalatest"   % "3.0.8",
-  "org.scalacheck" %% "scalacheck"  % "1.14.3",
-  "org.mockito"    % "mockito-core" % "3.3.3"
+  "org.scalatest"  %% "scalatest"    % "3.0.8",
+  "org.scalacheck" %% "scalacheck"   % "1.14.3",
+  "org.mockito"     % "mockito-core" % "3.3.3"
 ).map(_ % Test)
 
 Release.settings

--- a/src/test/scala/mockws/MockWSTest.scala
+++ b/src/test/scala/mockws/MockWSTest.scala
@@ -227,7 +227,7 @@ class MockWSTest extends FunSuite with Matchers with ScalaCheckPropertyChecks {
             }
         }
 
-        await(ws.url("/uri").addHttpHeaders(Seq(q           -> v): _*).get)
+        await(ws.url("/uri").addHttpHeaders(Seq(q -> v): _*).get)
         await(ws.url("/uri").addQueryStringParameters(Seq(q -> v): _*).get)
         ws.close()
       }


### PR DESCRIPTION
This PR supersedes #117 which upgrades scalafmt to version 2.5.2 and also re-configures and reformats the sources accordingly.

I tried to configure scalafmt to adhere to the current style as much as possible in order to minimize the changes done by running scalafmt.

Close #117, close #116 