### PR TITLE
added standalone client instead of the play 2.8 specific client.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 target
 .idea
 .idea_modules
+.vscode
+.metals
 logs
 .java-version
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ await(ws.url("http://dns/url").get()).body == "http response"
 
 Add MockWS as test dependency in the `build.sbt`:
 
+* for play-ws standalone 2.1.x:
+```scala
+libraryDependencies += "de.leanovate.play-mockws" %% "play-mockws" % "3.0.0" % Test
+```
 * for Play 2.8.x:
 ```scala
 libraryDependencies += "de.leanovate.play-mockws" %% "play-mockws" % "2.8.0" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -4,17 +4,16 @@ scalacOptions ++= Seq("-deprecation", "-feature")
 
 organization := "de.leanovate.play-mockws"
 
-val playVersion = "2.8.1"
+val playWsVersion = "2.1.7"
 
 fork := true
 
 resolvers += "Typesafe repository".at("https://repo.typesafe.com/typesafe/releases/")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play"      %% "play"                    % playVersion % "provided",
-  "com.typesafe.play"      %% "play-ahc-ws"             % playVersion % "provided",
-  "com.typesafe.play"      %% "play-test"               % playVersion % "provided",
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6"
+  "com.typesafe.play"      %% "play-ahc-ws-standalone"  % playWsVersion % "provided",
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6",
+  "com.typesafe.play"      %% "play-test"               % "2.8.11" % "provided",
 )
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/mockws/FakeAhcResponse.scala
+++ b/src/main/scala/mockws/FakeAhcResponse.scala
@@ -24,11 +24,11 @@ import scala.jdk.CollectionConverters._
 /**
  * A simulated response from the async-http-client.
  *
- * The [[play.api.libs.ws.ahc.AhcWSResponse]] is intended to wrap this.
+ * The [[play.api.libs.ws.ahc.StandaloneAhcWSResponse]] is intended to wrap this.
  *
  * Implementation is mostly based upon [[org.asynchttpclient.netty.NettyResponse]].
  *
- * We're faking at this level as opposed to the [[play.api.libs.ws.WSResponse]] level
+ * We're faking at this level as opposed to the [[play.api.libs.ws.StandaloneWSResponse]] level
  * to preserve any behavior specific to the NingWSResponse which is likely to be used
  * in the real (non-fake) WSClient.
  */

--- a/src/main/scala/mockws/MockWS.scala
+++ b/src/main/scala/mockws/MockWS.scala
@@ -1,18 +1,16 @@
 package mockws
 
 import java.util.UUID
-
 import scala.concurrent.Future
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import play.api.libs.ws.WSClient
-import play.api.libs.ws.WSRequest
+import play.api.libs.ws.{StandaloneWSClient, StandaloneWSRequest}
 import play.api.mvc.EssentialAction
 import play.api.mvc.Result
 import play.api.mvc.Results.NotFound
 
 /**
- * Mock implementation for the [[play.api.libs.ws.WSClient]].
+ * Mock implementation for the [[play.api.libs.ws.StandaloneWSRequest]].
  * Usage:
  * {{{
  *   val ws = MockWS {
@@ -38,7 +36,7 @@ import play.api.mvc.Results.NotFound
 class MockWS(routes: MockWS.Routes, shutdownHook: () => Unit)(
     implicit val materializer: Materializer,
     notFoundBehaviour: RouteNotDefined
-) extends WSClient {
+) extends StandaloneWSClient {
   require(routes != null)
 
   override def underlying[T]: T = this.asInstanceOf[T]
@@ -47,7 +45,7 @@ class MockWS(routes: MockWS.Routes, shutdownHook: () => Unit)(
     shutdownHook()
   }
 
-  override def url(url: String): WSRequest = FakeWSRequestHolder(routes, url)
+  override def url(url: String): StandaloneWSRequest = FakeWSRequestHolder(routes, url)
 }
 
 object MockWS {

--- a/src/test/scala/mockws/Example.scala
+++ b/src/test/scala/mockws/Example.scala
@@ -2,7 +2,7 @@ package mockws
 
 import mockws.MockWSHelpers._
 import org.scalatest.OptionValues
-import play.api.libs.ws.WSClient
+import play.api.libs.ws.StandaloneWSClient
 import play.api.mvc.Results._
 import play.api.test.Helpers._
 
@@ -21,7 +21,7 @@ object ImplementationToTest {
   }
 
   /** @param ws [[WSClient]] as dependency injection */
-  class GatewayToTest(ws: WSClient) {
+  class GatewayToTest(ws: StandaloneWSClient) {
 
     import GatewayToTest.userServiceUrl
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.8.2-SNAPSHOT"
+ThisBuild / version := "3.0.0-SNAPSHOT"


### PR DESCRIPTION
Wanted to get your thoughts on this.  As of play 2.6 the standalone client is separated from play.  So it would be nice to have this mocking library dependent as much as possible on the standalone client.

The one problem is that it does still require a play dependency to make everyting work.  Though it's only `play-test` and it seem like most the things being used from play-test have been pretty stable, but I'm not sure theres a way to remove the play dependency entirely to only have a dependency on standalone play client.