### PR TITLE
Play 2.9 & Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.10, 2.13.1]
+        scala: [2.13.1, 3.3.1]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -81,22 +81,22 @@ jobs:
           java-version: 8
           cache: sbt
 
-      - name: Download target directories (2.12.10)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-2.12.10-${{ matrix.java }}
-
-      - name: Inflate target directories (2.12.10)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
       - name: Download target directories (2.13.1)
         uses: actions/download-artifact@v3
         with:
           name: target-${{ matrix.os }}-2.13.1-${{ matrix.java }}
 
       - name: Inflate target directories (2.13.1)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.3.1)
+        uses: actions/download-artifact@v3
+        with:
+          name: target-${{ matrix.os }}-3.3.1-${{ matrix.java }}
+
+      - name: Inflate target directories (3.3.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.1, 3.3.1]
-        java: [temurin@8]
+        java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -31,12 +31,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
           cache: sbt
 
       - name: Lint
@@ -65,7 +65,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.18]
-        java: [temurin@8]
+        java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -73,12 +73,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
           cache: sbt
 
       - name: Download target directories (2.13.1)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ await(ws.url("http://dns/url").get()).body == "http response"
 
 Add MockWS as test dependency in the `build.sbt`:
 
+* for Play 2.9.x:
+```scala
+libraryDependencies += "de.leanovate.play-mockws" %% "play-mockws" % "2.9.0" % Test
+```
 * for Play 2.8.x:
 ```scala
 libraryDependencies += "de.leanovate.play-mockws" %% "play-mockws" % "2.8.0" % Test
@@ -143,6 +147,7 @@ Other examples can be found in the [tests](src/test/scala/mockws/).
 
 ## Compatibility Matrix
 
+- MockWS 2.9.x is actually only compatible with Play 2.9.y., with Scala 3 or 2.13.
 - MockWS 2.8.x is actually only compatible with Play 2.8.y., with Scala 2.13 or 2.12.
 - MockWS 2.6.x is actually only compatible with Play 2.6.y., with Scala 2.12 or 2.11.
 - MockWS 2.5.x is actually only compatible with Play 2.5.y., with Scala 2.11.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Release notes
 
+# 2.9.0
+
+This release targets Play 2.9 and Akka 2.6. Scala 2.12 and Java 8 are longer supported.
+
+See [v2.9.0](https://github.com/leanovate/play-mockws/releases/tag/v2.9.0) for a full list of changes.
+
 ## 2.8.1
 
 - add support for request filters (#150) @avdv

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,8 @@ libraryDependencies ++= Seq(
 
 Release.settings
 
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
+
 // code linting
 ThisBuild / githubWorkflowBuildPreamble += WorkflowStep.Run(
   commands = List("scripts/validate-code check"),

--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,12 @@ libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                    % playVersion % "provided",
   "com.typesafe.play"      %% "play-ahc-ws"             % playVersion % "provided",
   "com.typesafe.play"      %% "play-test"               % playVersion % "provided",
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6"
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest"     %% "scalatest"       % "3.2.8",
-  "org.scalatestplus" %% "scalacheck-1-15" % "3.2.8.0",
+  "org.scalatest"     %% "scalatest"       % "3.2.17",
+  "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0",
   "org.scalacheck"    %% "scalacheck"      % "1.15.4",
   "org.mockito"        % "mockito-core"    % "3.11.0"
 ).map(_ % Test)

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ scalacOptions ++= Seq("-deprecation", "-feature")
 
 organization := "de.leanovate.play-mockws"
 
-val playVersion = "2.8.1"
+val playVersion = "2.9.0"
 
-ThisBuild / crossScalaVersions := List("2.12.10", "2.13.1")
+ThisBuild / crossScalaVersions := List("2.13.1", "3.3.1")
 
 fork := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,9 @@ fork := true
 resolvers += "Typesafe repository".at("https://repo.typesafe.com/typesafe/releases/")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play"      %% "play"                    % playVersion % "provided",
-  "com.typesafe.play"      %% "play-ahc-ws"             % playVersion % "provided",
-  "com.typesafe.play"      %% "play-test"               % playVersion % "provided",
+  "com.typesafe.play" %% "play"        % playVersion % "provided",
+  "com.typesafe.play" %% "play-ahc-ws" % playVersion % "provided",
+  "com.typesafe.play" %% "play-test"   % playVersion % "provided",
 )
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                    % playVersion % "provided",
   "com.typesafe.play"      %% "play-ahc-ws"             % playVersion % "provided",
   "com.typesafe.play"      %% "play-test"               % playVersion % "provided",
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"
 )
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version = 1.9.3
+sbt.version = 1.9.7
+

--- a/src/main/scala/mockws/FakeWSRequestHolder.scala
+++ b/src/main/scala/mockws/FakeWSRequestHolder.scala
@@ -45,6 +45,7 @@ case class FakeWSRequestHolder(
   /* Not implemented. */
   val calc: Option[WSSignatureCalculator] = None
   val followRedirects: Option[Boolean]    = None
+  val disableUrlEncoding: Option[Boolean] = None
   val proxyServer: Option[WSProxyServer]  = None
   val virtualHost: Option[String]         = None
 
@@ -55,6 +56,8 @@ case class FakeWSRequestHolder(
 
   def withFollowRedirects(follow: Boolean): Self = this
 
+  def withDisableUrlEncoding(disableUrlEncoding: Boolean): Self = this
+
   def withProxyServer(proxyServer: WSProxyServer): Self = this
 
   def withVirtualHost(vh: String): Self = this
@@ -64,6 +67,8 @@ case class FakeWSRequestHolder(
   def withMethod(method: String): Self = copy(method = method)
 
   def withCookies(cookie: WSCookie*): Self = copy(cookies = this.cookies ++ cookie.toSeq)
+
+  override def addCookies(cookies: WSCookie*): Self = withCookies(this.cookies ++ cookies: _*)
 
   def withHeaders(hdrs: (String, String)*): Self = withHttpHeaders(hdrs: _*)
 

--- a/src/test/scala/mockws/AuthenticationTest.scala
+++ b/src/test/scala/mockws/AuthenticationTest.scala
@@ -26,10 +26,10 @@ class AuthenticationTest extends AnyFunSuite with Matchers with ScalaCheckProper
       }
     }
 
-    val wsResponseOk = await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.BASIC).get)
+    val wsResponseOk = await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.BASIC).get())
     wsResponseOk.status shouldEqual OK
 
-    val wsResponseUnauthorized = await(ws.url("/").withAuth("user", "secret", WSAuthScheme.BASIC).get)
+    val wsResponseUnauthorized = await(ws.url("/").withAuth("user", "secret", WSAuthScheme.BASIC).get())
     wsResponseUnauthorized.status shouldEqual UNAUTHORIZED
 
     ws.close()
@@ -45,16 +45,16 @@ class AuthenticationTest extends AnyFunSuite with Matchers with ScalaCheckProper
     }
 
     a[UnsupportedOperationException] shouldBe thrownBy(
-      await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.NTLM).get)
+      await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.NTLM).get())
     )
     a[UnsupportedOperationException] shouldBe thrownBy(
-      await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.DIGEST).get)
+      await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.DIGEST).get())
     )
     a[UnsupportedOperationException] shouldBe thrownBy(
-      await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.KERBEROS).get)
+      await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.KERBEROS).get())
     )
     a[UnsupportedOperationException] shouldBe thrownBy(
-      await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.SPNEGO).get)
+      await(ws.url("/").withAuth("user", "s3cr3t", WSAuthScheme.SPNEGO).get())
     )
 
   }

--- a/src/test/scala/mockws/Example.scala
+++ b/src/test/scala/mockws/Example.scala
@@ -11,6 +11,7 @@ import scala.concurrent.Future
 import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.libs.ws.readableAsString
 
 object ImplementationToTest {
 

--- a/src/test/scala/mockws/MockWSTest.scala
+++ b/src/test/scala/mockws/MockWSTest.scala
@@ -20,6 +20,9 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import play.api.libs.ws.writeableOf_String
+import play.api.libs.ws.readableAsString
+import play.api.libs.ws.writeableOf_JsValue
 
 /**
  * Tests that [[MockWS]] simulates a WS client
@@ -180,7 +183,7 @@ class MockWSTest extends AnyFunSuite with Matchers with ScalaCheckPropertyChecks
       }
     }
 
-    val wsResponse = await(ws.url("/").addHttpHeaders(CONTENT_TYPE -> "hello/world").get)
+    val wsResponse = await(ws.url("/").addHttpHeaders(CONTENT_TYPE -> "hello/world").get())
     wsResponse.status shouldEqual OK
     wsResponse.body shouldEqual "hello/world"
     ws.close()
@@ -198,7 +201,7 @@ class MockWSTest extends AnyFunSuite with Matchers with ScalaCheckPropertyChecks
           }
         }
 
-        val wsResponse = await(ws.url("/uri").addQueryStringParameters(q -> v).get)
+        val wsResponse = await(ws.url("/uri").addQueryStringParameters(q -> v).get())
         wsResponse.status shouldEqual OK
         wsResponse.body shouldEqual v
         ws.close()
@@ -218,8 +221,8 @@ class MockWSTest extends AnyFunSuite with Matchers with ScalaCheckPropertyChecks
           }
         }
 
-        await(ws.url("/uri").addHttpHeaders(Seq(q -> v): _*).get)
-        await(ws.url("/uri").addQueryStringParameters(Seq(q -> v): _*).get)
+        await(ws.url("/uri").addHttpHeaders(Seq(q -> v): _*).get())
+        await(ws.url("/uri").addQueryStringParameters(Seq(q -> v): _*).get())
         ws.close()
       }
     }

--- a/src/test/scala/mockws/StreamingTest.scala
+++ b/src/test/scala/mockws/StreamingTest.scala
@@ -11,10 +11,13 @@ import play.api.mvc.MultipartFormData.DataPart
 import play.api.mvc.MultipartFormData.FilePart
 import play.api.mvc.MultipartFormData.Part
 import play.api.mvc.Results._
+import play.api.mvc.AnyContent
+import play.api.mvc.Request
 import play.api.mvc.ResponseHeader
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.api.libs.ws.readableAsString
 
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext.Implicits._
@@ -122,7 +125,7 @@ class StreamingTest extends AnyFunSuite with Matchers with ScalaCheckPropertyChe
     ws.close()
   }
 
-  val streamBackAction = Action { req =>
+  val streamBackAction = Action { (req: Request[AnyContent]) =>
     val inputWords: Seq[String]             = Seq() ++ req.body.asMultipartFormData.toSeq.flatMap(_.dataParts("k1"))
     val returnWords                         = Seq(req.method + ": ") ++ inputWords
     val outputStream: Source[ByteString, _] = Source(returnWords.map(v => ByteString(v)))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.8.2-SNAPSHOT"
+ThisBuild / version := "2.9.0"


### PR DESCRIPTION
## What this changes

Play 2.9 was just released, this PR bumps `play-mockws` to the newest version. Play 3.x has also just been released but will involve some breaking changes, figure some people might have some benefit to having a Play 2.9 version of this library before then.

## How this was tested

Tests ran against Scala 2.13 and Scala 3 with:

`sbt ++3.3.1! test`
`sbt ++2.13.1! test`