### PR TITLE
chore(deps): update dependency com.github.sbt:sbt-ci-release to v1.11.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import scala.collection.immutable
-import xerial.sbt.Sonatype.sonatypeCentralHost
 
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature")
 
@@ -118,9 +117,3 @@ lazy val play30 = (project in file("play-mockws"))
     Test / unmanagedSourceDirectories += (Test / sourceDirectory).value / "play-3",
     Test / unmanagedSourceDirectories += (Test / sourceDirectory).value / "play-3-0",
   )
-
-// Publish to Central Portal
-// https://github.com/xerial/sbt-sonatype?tab=readme-ov-file#sonatype-central-host
-ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
-// Sonatype profile for releases (otherwise it uses the organization name)
-sonatypeProfileName := "de.leanovate"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "3.0.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 
 // https://github.com/sbt/sbt-ci-release
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.0")
 
 // Scoverage coverage-parser relies on version 1.x
 // scala-xml 2.0 is most of the time non breaking


### PR DESCRIPTION
Supersedes https://github.com/leanovate/play-mockws/pull/556

This will be merged as an attempt to see if we can publish without using `sonatypeProfileName` with Central Portal maybe. If not, I'll revert.