### PR TITLE
docs: update maven badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Play MockWS
 =================
 
 ![CI Workflow](https://github.com/leanovate/play-mockws/actions/workflows/ci.yml/badge.svg)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/de.leanovate.play-mockws/play-mockws-3-0_3/badge.svg)](https://maven-badges.herokuapp.com/maven-central/de.leanovate.play-mockws/play-mockws-3-0_3)
+[![Maven Central](https://img.shields.io/maven-central/v/de.leanovate.play-mockws/play-mockws-3-0_3)](https://central.sonatype.com/namespace/de.leanovate.play-mockws)
 
 * [Goal](#goal)
 * [Simple example](#example)


### PR DESCRIPTION
* use Central Sonatype compatible URL
* use img.shields.io directly instead of https://maven-badges.herokuapp.com or https://maven-badges.sml.io