### PR TITLE
🧹 chore: upgrade Play to 3.0.9

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 3.1.0
+
+- Update Play to 2.9.9/3.0.9
+
 ## 3.0.9
 
 - Update Play to 2.9.8/3.0.8

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ ThisBuild / developers := List(
 
 val play28Version = "2.8.22"
 val play29Version = "2.9.9"
-val play30Version = "3.0.8"
+val play30Version = "3.0.9"
 
 def play2Dependencies(version: String): Seq[ModuleID] = Seq(
   "com.typesafe.play" %% "play"        % version,


### PR DESCRIPTION
Fixes wrong update by Scala Steward https://github.com/leanovate/play-mockws/pull/590